### PR TITLE
Fix broken root and 404 routes

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -7,6 +7,7 @@ const serverErrors = require('./util/server-errors');
 const loadResourceConfigs = require('./util/load-resource-configs');
 const sendJson = require('./util/send-json');
 const migrate = require('./util/migrate');
+const jsonApiHeaders = require('./util/json-api-headers');
 
 module.exports = function() {
   // Run our migrations each time the app is started to make sure that we're
@@ -14,6 +15,7 @@ module.exports = function() {
   migrate.up();
 
   const router = express.Router();
+  router.use(jsonApiHeaders);
 
   // This version needs to be made external
   var apiVersion = 1;
@@ -39,7 +41,7 @@ module.exports = function() {
   router.get('/', (req, res) => {
     sendJson(res, {
       version: 'v1',
-      endpoints: definitions.map(resource => {
+      endpoints: resources.map(resource => {
         return {
           route: resource.location,
           methods: Object.keys(resource.routes)
@@ -50,7 +52,7 @@ module.exports = function() {
 
   // All other requests get a default 404 error.
   router.get('*', (req, res) => {
-    res.status(serverErrors.notFound.code);
+    res.status(404);
     sendJson(res, {
       errors: [serverErrors.notFound.body()]
     });

--- a/server/resource/routes.js
+++ b/server/resource/routes.js
@@ -2,7 +2,6 @@
 
 const controller = require('./controller');
 const validator = require('../util/validator');
-const jsonApiHeaders = require('../util/json-api-headers');
 
 module.exports = function({version, pluralResourceName, routes, controller, validations}) {
   return {
@@ -13,7 +12,6 @@ module.exports = function({version, pluralResourceName, routes, controller, vali
     routes: {
       post: {
         '/': [
-          jsonApiHeaders,
           validator(validations.create),
           controller.create
         ]
@@ -21,12 +19,10 @@ module.exports = function({version, pluralResourceName, routes, controller, vali
 
       get: {
         '/': [
-          jsonApiHeaders,
           validator(validations.readMany),
           controller.read
         ],
         '/:id': [
-          jsonApiHeaders,
           validator(validations.readOne),
           controller.read
         ]
@@ -34,7 +30,6 @@ module.exports = function({version, pluralResourceName, routes, controller, vali
 
       patch: {
         '/:id': [
-          jsonApiHeaders,
           validator(validations.update),
           controller.update
         ]
@@ -42,7 +37,6 @@ module.exports = function({version, pluralResourceName, routes, controller, vali
 
       delete: {
         '/:id': [
-          jsonApiHeaders,
           validator(validations.delete),
           controller.delete
         ]

--- a/server/util/send-json.js
+++ b/server/util/send-json.js
@@ -6,5 +6,6 @@
 // For more on Express' behavior:
 // https://github.com/expressjs/express/issues/2921
 module.exports = function(res, body) {
+  body = body || {};
   return res.send(new Buffer(JSON.stringify(body)));
 };


### PR DESCRIPTION
Resolves #17

The issue is that `res.send()` sets the Content-Type header based on what's passed in, unless you automatically set the header. `sendJson` does not automatically set the header, and my jsonApiHeaders middleware wasn't registered for all routes. Because sendJson sends a Buffer, the Content-Type set by res.send ended up not being what I wanted.

This ensures that the jsonApiHeaders middleware comes first, so that the header gets set, so that sendJson works as expected.